### PR TITLE
Fix module

### DIFF
--- a/API/index.ts
+++ b/API/index.ts
@@ -1,11 +1,12 @@
 import {Server} from "./src/server";
 import {TravelStatusStorageHandler} from "./src/storageHandlers/TravelStatusStorageHandler";
-import {StatusReader, StatusWriter} from "./src/travelStatusStore/StatusStore";
+import {InMemoryTravelStatusReader, InMemoryTravelStatusWriter, StatusReader, StatusWriter} from './src/travelStatusStore/StatusStore';
 import {TravelStatusRetrievalHandler} from "./src/retrievalHandlers/TravelStatusRetrievalHandler";
 import {TravelBansStorageHandler} from "./src/storageHandlers/TravelBansStorageHandler";
 import {BasicAuthAuthenticator, BasicAuthCredentials} from "./src/auth/Authenticator";
+import {SqlStatusReader, SqlTravelStatusWriter} from './src/travelStatusStore/SqlStatusStore';
 
-export async function start(statusWriter: StatusWriter, statusReader: StatusReader, credentials: BasicAuthCredentials) : Promise<void> {
+const start = async (statusWriter: StatusWriter, statusReader: StatusReader, credentials: BasicAuthCredentials) : Promise<void> => {
   const server = new Server(
     new TravelStatusRetrievalHandler(statusReader),
     new TravelStatusStorageHandler(statusWriter),
@@ -14,3 +15,14 @@ export async function start(statusWriter: StatusWriter, statusReader: StatusRead
   );
   server.start();
 }
+
+export {
+  BasicAuthCredentials,
+  StatusReader,
+  StatusWriter,
+  SqlStatusReader,
+  SqlTravelStatusWriter,
+  InMemoryTravelStatusReader,
+  InMemoryTravelStatusWriter,
+  start
+};

--- a/API/package.json
+++ b/API/package.json
@@ -1,11 +1,12 @@
 {
   "name": "covid-travel-store",
   "version": "1.0.5",
-  "main": "index.ts",
-  "types": "index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "mocha **/*.test.ts --require ts-node/register",
-    "start": "ts-node index.ts"
+    "start": "ts-node index.ts",
+    "prepublish": "tsc"
   },
   "repository": {
     "type": "git",

--- a/API/package.json
+++ b/API/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/isabelcooper/coronApi.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/isabelcooper/coronApi/issues"
   },

--- a/API/tsconfig.json
+++ b/API/tsconfig.json
@@ -7,7 +7,6 @@
       "es2015",
       "dom"
     ],
-    "noEmit": true,
     "downlevelIteration": true,
     "strict": true,
     "noImplicitAny": true,
@@ -15,14 +14,18 @@
     "strictFunctionTypes": true,
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
     "noImplicitThis": true,
     "alwaysStrict": true,
     "skipLibCheck": true
   },
   "include": [
+    "*.ts",
     "**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dist"
   ]
 }


### PR DESCRIPTION
1. Typescript exports compiled files to dist
2. Re-export common types and classes to simplify imports
    >  Note: re-exporting messes with tree shaking so this isn't recommended for browser code (including isomorphic code) but is ok here for node
3. Fixed the license