### PR TITLE
Change run to install node version if not present

### DIFF
--- a/run
+++ b/run
@@ -21,7 +21,7 @@ install_node () {
         set -e
     fi
 
-    nvm use "${NODE_VERSION}"
+    nvm install "${NODE_VERSION}"
 }
 
 install_node_dependencies () {


### PR DESCRIPTION
I checked out the code, executed './run' and nothing happened. I didn't have the correct version of node installed on my machine. As the install_node is protected via a version_check this shouldn't introduce a performance hit on normal runs.